### PR TITLE
Focus contribution suggestions to labelled issues

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -200,8 +200,9 @@ Further development work is strongly encouraged - please get in touch or check o
 <h4 id="-lesson-contributing"><a id="lesson-contributing"></a>Contributing to Lessons</h4>
 
 <p>All contributions are welcome, but if you would like to focus your efforts where they are most needed, please work
-   on <a href="https://github.com/search?q=org%3ALibraryCarpentry+label%3Agood-first-patch&type=Issues">issues that are 
-   labeled <code>good-first-patch</code></a>. We recommend that you <code>@mention</code> the Maintainers of the lesson
+   on issues that are labeled <a href="<a href="https://github.com/search?q=org%3ALibraryCarpentry+label%3A%22help+wanted%22">
+      <code>help wanted</code></a> or <a href="<a href="https://github.com/search?q=org%3ALibraryCarpentry+label%3A%22goodfirst+issue%22">
+   <code>good first issue</code></a>. We recommend that you <code>@mention</code> the Maintainers of the lesson
    if you are picking up the tasks described in one of those issues.</p>
 
 <h4 id="-lesson-development"><a id="lesson-development"></a>Lesson Development Process</h4>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -200,9 +200,9 @@ Further development work is strongly encouraged - please get in touch or check o
 <h4 id="-lesson-contributing"><a id="lesson-contributing"></a>Contributing to Lessons</h4>
 
 <p>All contributions are welcome, but if you would like to focus your efforts where they are most needed, please work
-on the alpha, beta, and conceptual lessons. Contributions can be made in the form of issues and pull requests to the 
-   <a href="https://github.com/LibraryCarpentry">Library Carpentry lessons on GitHub</a>. We recommend that you reach 
-   out to the Maintainers of the lessons, as well, if you are considering/suggesting substantial changes.</p>
+   on <a href="https://github.com/search?q=org%3ALibraryCarpentry+label%3Agood-first-patch&type=Issues">issues that are 
+   labeled <code>good-first-patch</code></a>. We recommend that you <code>@mention</code> the Maintainers of the lesson
+   if you are picking up the tasks described in one of those issues.</p>
 
 <h4 id="-lesson-development"><a id="lesson-development"></a>Lesson Development Process</h4>
 


### PR DESCRIPTION
I feel that the language there is too broad, leaving people with too many options and no clear start. Conceptual languages should honestly not be suggested to new contributors, because their authors may not have even decided. *EDIT: On the broad strokes / goals of the lesson, I mean. I'm presuming here that we agreed to make it their prerogative to define those.*

- [ ] In case you agree that we should point them to the exact issues labeled in a certain way, we first need to label some of such issues with `good first issue` and/or `help wanted` (both [GitHub](https://help.github.com/articles/about-labels/) or [Carpentries](https://docs.carpentries.org/topic_folders/maintainers/github_labels.html) labelling scheme match there)